### PR TITLE
delete find_tender_by_funder_id test

### DIFF
--- a/op_robot_tests/tests_files/openProcedure.robot
+++ b/op_robot_tests/tests_files/openProcedure.robot
@@ -39,6 +39,7 @@ ${MOZ_INTEGRATION}  ${False}
 
 
 Можливість знайти тендер за кошти донора по ідентифікатору донора
+# invalid test case because of functional changes - this type of search can`t be done any more
   [Tags]   ${USERS.users['${viewer}'].broker}: Пошук тендера
   ...      viewer  tender_owner  provider  provider1
   ...      ${USERS.users['${viewer}'].broker}  ${USERS.users['${tender_owner}'].broker}

--- a/robot_tests_arguments/below_funders.txt
+++ b/robot_tests_arguments/below_funders.txt
@@ -11,7 +11,6 @@
 
 -i create_tender
 -i find_tender
--i find_tender_by_funder_id
 -i tender_view
 -i tender_view_value
 -i tender_view_minimalStep

--- a/robot_tests_arguments/below_funders_full.txt
+++ b/robot_tests_arguments/below_funders_full.txt
@@ -11,7 +11,6 @@
 
 -i create_tender
 -i find_tender
--i find_tender_by_funder_id
 -i tender_view
 -i tender_view_value
 -i tender_view_minimalStep


### PR DESCRIPTION
данний тест кейс більше не може бути виконаний через нещодавні зміни в індексації БД