### PR TITLE
fix waiting for auctions/disable add doc test in selection

### DIFF
--- a/op_robot_tests/tests_files/openProcedure.robot
+++ b/op_robot_tests/tests_files/openProcedure.robot
@@ -2655,7 +2655,8 @@ ${PLAN_TENDER}      ${True}
   ...      ${USERS.users['${viewer}'].broker}
   ...      auction_url
   ...      critical
-  [Setup]  Дочекатись дати початку періоду аукціону  ${viewer}  ${TENDER['TENDER_UAID']}
+  Дочекатись дати закінчення прийому пропозицій  ${viewer}  ${TENDER['TENDER_UAID']}
+  Дочекатись дати початку періоду аукціону  ${viewer}  ${TENDER['TENDER_UAID']}
   Можливість отримати посилання на аукціон для глядача
 
 

--- a/robot_tests_arguments/framework_selection.txt
+++ b/robot_tests_arguments/framework_selection.txt
@@ -21,7 +21,7 @@
 -i modify_item
 -i modify_lot
 
--i add_tender_doc
+
 
 -i extend_tendering_period
 


### PR DESCRIPTION
- прибрано тест додавання документів в тендер на другому етапі рамкових угоди (не повинно проводитись згідно умов)
- дадано фикс очікування кінця періоду подачі пропозицій та початку періоду аукціону, потрібно для сценаріїв надпорогових процедур