### PR TITLE
fix the dpath version for python2.7

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -97,3 +97,4 @@ cryptography = 2.3.1
 pyOpenSSL = 18.0.0
 python-dateutil = 2.7.5
 Pillow = 6.2.2
+dpath = 1.5.0


### PR DESCRIPTION
зафиксовано версию пакета dpath для python 2.7