### PR TITLE
CS-7555

### DIFF
--- a/op_robot_tests/tests_files/qualification.robot
+++ b/op_robot_tests/tests_files/qualification.robot
@@ -291,6 +291,7 @@ ${award_index}      ${0}
   ...  ${USERS.users['${tender_owner}'].broker}
   ...  qualification_add_doc_to_first_award
   ...  critical
+  [Setup]  Дочекатись дати початку періоду кваліфікації  ${tender_owner}  ${TENDER['TENDER_UAID']}
   ${file_path}  ${file_name}  ${file_content}=   create_fake_doc
   Run As   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${file_path}   ${TENDER['TENDER_UAID']}   0
   Remove File  ${file_path}


### PR DESCRIPTION
CS-7555 add wait for active.qualification tender status to avoid error Resolving variable '${tender.data.awards[0].id}' failed: AttributeError: awards