### PR TITLE
CS-10524

### DIFF
--- a/op_robot_tests/tests_files/base_keywords.robot
+++ b/op_robot_tests/tests_files/base_keywords.robot
@@ -608,6 +608,7 @@ ${ERROR_PLAN_MESSAGE}=  Calling method 'get_plan' failed: ResourceGone: {"status
 
 
 Звірити відображення поля ${field} документа ${doc_id} із ${left} для користувача ${username}
+  Sleep  30s
   ${right}=  Run As  ${username}  Отримати інформацію із документа  ${TENDER['TENDER_UAID']}  ${doc_id}  ${field}
   Порівняти об'єкти  ${left}  ${right}
 

--- a/robot_tests_arguments/framework_agreement_full.txt
+++ b/robot_tests_arguments/framework_agreement_full.txt
@@ -70,8 +70,7 @@
 -i auction
 
 -i qualification_add_doc_to_first_award
--i qualification_add_criteria_response_first_award
--i qualification_reject_first_award
+-i qualification_approve_first_award
 -i qualification_add_doc_to_second_award
 -i qualification_approve_second_award
 -i qualification_approve_third_award


### PR DESCRIPTION
1) we need sleep because from time to time system can`t add doc to contract so fast as result test fails - we can`t track the bug it is very random
2) change framework test suite back -  because we need 3 providers to continue